### PR TITLE
add option to disable auto text expander

### DIFF
--- a/app/scripts/ate.js
+++ b/app/scripts/ate.js
@@ -232,6 +232,10 @@ jQuery.noConflict();
   {
     debugLog('processAutoTextExpansion:', autotext, capitalization);
 
+    if (disableAutoExpander()) {
+      return;
+    }
+
     // Check if shortcut exists and should be triggered
     if (autotext && textInput)
     {
@@ -1204,6 +1208,10 @@ jQuery.noConflict();
         })
       );
     }
+  }
+
+  function disableAutoExpander() {
+    return !!$('*[data-disable-auto-expander]').length;
   }
 
   // Document ready function


### PR DESCRIPTION
The extension causes unwanted behavior with content editable. Draft.js is a very popular library for many sites (created and used by Facebook / comments). 